### PR TITLE
Mobile style fix

### DIFF
--- a/styles/Accordion.module.css
+++ b/styles/Accordion.module.css
@@ -87,6 +87,7 @@
     margin-right: 2px;
     padding: 0 10px 0 0;
   }
+  .accordionItemPanel,
   .open .accordionItemPanel{
     padding: 0 1rem;
     font-size: 16px;


### PR DESCRIPTION
- Text in accordion panels would resize each time it was opened (since the default panel still used the desktop font size)